### PR TITLE
Refactor/extend OAuth docs

### DIFF
--- a/docs/web-services/auth.md
+++ b/docs/web-services/auth.md
@@ -1,49 +1,54 @@
 # Auth
 
-Authentication is available through OAuth2. 
+Authentication is available through OAuth2.
+
+## Registration
+
+You can register your application and get your credentials at [api.trackmania.com](https://api.trackmania.com).
+After you created your application, make sure to save your `Identifier` (client ID) and `Secret` (client secret) for later.
 
 ## Grants
 
 ### Auth code flow
 
-1. Redirect the user to https://api.trackmania.com/oauth/authorize with the query parameters:
+1. Redirect the user to https://api.trackmania.com/oauth/authorize with the following query parameters:
     - `response_type`: `code`
-    - `client_id`: the client ID you created in the manager
-    - `scope`: space separated value of scopes
-    - `redirect_uri`: one of the redirect URIs in the application you created in the manager
-    - `state`: a non predictable random string. You should store this value and check if the value is the same at later stage.
-2. After the user authorize your application, they are redirected to the `redirect_uri` with the query parameter:
-    - `code`: a code you need to exchange for an access token
-    - `state`: check that it's the same value than then one you generated at step 1.
-3. The application should issue a `POST` request to https://api.trackmania.com/api/access_token with the parameters:
+    - `client_id`: The client ID ("Identifier") you created in the manager.
+    - `scope`: Space separated value of scopes. See [here](#scopes) for more information.
+    - `redirect_uri`: One of the redirect URIs in the application you created in the manager.
+    - `state`: A non predictable random string. You should store this value and check if the value is the same at later stage.
+2. After the user authorized your application, they are redirected to the `redirect_uri` with these query parameters:
+    - `code`: A code you need to exchange for an access token.
+    - `state`: Check that this is the same value as the one you generated at step 1.
+3. The application should now issue a `POST` request to https://api.trackmania.com/api/access_token with these parameters:
     - `grant_type`: `authorization_code`
-    - `client_id`: your client ID
-    - `client_secret`: your client secret
-    - `code`: the code from stage 2
-    - `redirect_uri`: from stage 1
+    - `client_id`: Your client ID.
+    - `client_secret`: Your client secret.
+    - `code`: The code from stage 2.
+    - `redirect_uri`: The redirect URI that was used in stage 1.
 
 The answer of stage 3 will contain:
 
-   - `token_type`
-   - `expires_in`
-   - `access_token`
-   - `refresh_token`
+   - `token_type`: This determines how you'll use the token. `bearer` means you send it alongside your requests in the `Authorization` header with the format `Bearer <token>`.
+   - `expires_in`: The number of seconds this token will remain valid.
+   - `access_token`: The token you need to access the endpoints on `api.trackmania.com`.
 
-### Client credentials 
+### Client credentials
 
-This is ment to be used for machine-to-machine authentication. 
+This is meant to be used for machine-to-machine authentication.
+Note that this token will not be associated with a user, so not all `api.trackmania.com` endpoints might make sense in this scenario.
 
 1. Issue a `POST` request to https://api.trackmania.com/api/access_token with the parameters:
     - `grant_type`: `client_credentials`
-    - `client_id`: your client ID
-    - `client_secret`: your client secret
-    - `scope`: space delimited list of scopes
-    
-The answer will container
+    - `client_id`: The client ID ("Identifier") you created in the manager.
+    - `client_secret`: The client secret ("Secret") associated with your client ID.
+    - `scope`: Space separated value of scopes. See [here](#scopes) for more information.
 
-   - `token_type`
-   - `expires_in`
-   - `access_token`
+The answer will contain:
+
+   - `token_type`: This determines how you'll use the token. `bearer` means you send it alongside your requests in the `Authorization` header with the format `Bearer <token>`.
+   - `expires_in`: The number of seconds this token will remain valid.
+   - `access_token`: The token you need to access the endpoints on `api.trackmania.com`.
 
 ### Implicit grant
 
@@ -51,4 +56,4 @@ As it's no longer a good practice, implicit grant won't be available.
 
 ## Scopes
 
-For now, only empty scope is supported. 
+For now, only an empty scope is supported.

--- a/docs/web-services/index.md
+++ b/docs/web-services/index.md
@@ -1,13 +1,13 @@
 # Web services
 
-You can create your credentials on the [developper website](https://api.trackmania.com). 
+You can create your credentials on the [developer website (api.trackmania.com)](https://api.trackmania.com).
 
 ## Documentation
 
-[The documentation is available on the developper website](https://api.trackmania.com/doc)
+The available routes are described [here](https://api.trackmania.com/doc).
 
-## Authentication 
+## Authentication
 
-After retreiving your client ID you need to get an access token. All the method to get one are described in [auth].
+After retrieving your client ID you need to get an access token. All the methods to get one are described in [auth].
 
 [auth]: auth/


### PR DESCRIPTION
The OAuth docs are a good baseline, but I've heard a couple people complain about their limitations - they're not 100% complete and make some assumptions about the reader's knowledge.

I don't think it's required to explain OAuth and the use cases in here - instead I created a separate alternative documentation (https://gist.github.com/davidbmaier/ae14d365b41aa719ed0256b6e41a4a09).

Also, this repo doesn't seem to hold any of the Swagger/OAS3 information (the stuff displayed [here](https://api.trackmania.com/doc)). I think that deserves a second pass as well for two reasons:
- It doesn't explain how to pass the token to the endpoint (not everyone will immediately assume they'll need to use the `Authorization` header with the `Bearer` prefix).
- None of the "Try it out" buttons can work if there's no way to provide a token to test them - so either you could disable the button for the gated endpoints, or you could look into adding a token parameter. Always returning `401` is not very helpful.😅 

Changes:
- Fixed typos and rephrased a couple sentences.
- Added explanations to scopes, client IDs, and client secrets.
- Added more information about the `/access_token` response - especially how to use the token.
- Removed mention of the `redirect_token` since it doesn't seem to get returned (and there's also no documented route to use it with anyway) - this might just be due to my lack of knowledge. If it is in fact supported, let me know and I'll add it back in.