### PR TITLE
Add note that login is required for reports

### DIFF
--- a/docs/general/how-to-report-player.md
+++ b/docs/general/how-to-report-player.md
@@ -36,10 +36,10 @@ Note that using this website, you can also report individual maps and/or clubs -
 
 ## Ubisoft support
 
-Head over to the [official Ubisoft Support website](https://www.ubisoft.com/en-gb/help/contact).
+Head over to the [official Ubisoft Support website](https://www.ubisoft.com/en-gb/help/contact). Make sure you're logged in, otherwise the site won't let you submit a report.
 
-- **Platform**: Your platform of choice
 - **Game**: Trackmania
+- **Platform**: Your platform of choice
 - **Category**: Player Reports, Bans, and Sanctions
 - **Sub-Category**: Learn the Rules/Report a player
 


### PR DESCRIPTION
After some confusion from a player that wanted to report someone, we figured out that a login on the website is required, otherwise it might redirect to other support articles.
Just adding that here to make it clear for future reference.