### PR TITLE
Update deployment runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Ubuntu 20.04 runners are no longer supported, so this updates the referenced runner image for deployment to Ubuntu 24.04.

See https://github.com/nadeo/trackmania-doc/actions/runs/15275733965 and https://github.com/actions/runner-images/issues/11101 for reference.